### PR TITLE
Fix getLoggedInUser() potentially throwing a ClassCastException

### DIFF
--- a/src/main/java/de/adesso/kicker/configurations/KeycloakSecurityConfig.java
+++ b/src/main/java/de/adesso/kicker/configurations/KeycloakSecurityConfig.java
@@ -48,7 +48,7 @@ public class KeycloakSecurityConfig extends KeycloakWebSecurityConfigurerAdapter
     protected void configure(HttpSecurity http) throws Exception {
         super.configure(http);
         http.authorizeRequests()
-                .antMatchers("/", "/home", "/users/u/**")
+                .antMatchers("/", "/home", "/ranking", "/users/u/**", "/css/**", "/js/**", "/img/**")
                 .permitAll()
                 .anyRequest()
                 .authenticated()

--- a/src/main/java/de/adesso/kicker/notification/matchverificationrequest/persistence/MatchVerificationRequestRepository.java
+++ b/src/main/java/de/adesso/kicker/notification/matchverificationrequest/persistence/MatchVerificationRequestRepository.java
@@ -1,7 +1,6 @@
 package de.adesso.kicker.notification.matchverificationrequest.persistence;
 
 import de.adesso.kicker.match.persistence.Match;
-import de.adesso.kicker.user.persistence.User;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/de/adesso/kicker/site/controller/HomeController.java
+++ b/src/main/java/de/adesso/kicker/site/controller/HomeController.java
@@ -1,7 +1,7 @@
 package de.adesso.kicker.site.controller;
 
-import de.adesso.kicker.ranking.persistence.Ranking;
 import de.adesso.kicker.ranking.service.RankingService;
+import de.adesso.kicker.user.exception.UserNotFoundException;
 import de.adesso.kicker.user.service.UserService;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,11 +25,16 @@ public class HomeController {
             @RequestParam(defaultValue = "10") int size) {
         ModelAndView modelAndView = new ModelAndView();
         var users = userService.getUserPageSortedByRating(page, size);
-        var user = userService.getLoggedInUser();
-        var rank = rankingService.getPositionOfPlayer(user.getRanking());
+        try {
+            var user = userService.getLoggedInUser();
+            var rank = rankingService.getPositionOfPlayer(user.getRanking());
+            modelAndView.addObject("user", user);
+            modelAndView.addObject("rank", rank);
+        } catch (UserNotFoundException e) {
+            modelAndView.addObject("user", false);
+            modelAndView.addObject("rank", false);
+        }
         modelAndView.addObject("users", users);
-        modelAndView.addObject("user", user);
-        modelAndView.addObject("rank", rank);
         modelAndView.setViewName("sites/ranking.html");
         return modelAndView;
     }

--- a/src/main/java/de/adesso/kicker/user/service/UserService.java
+++ b/src/main/java/de/adesso/kicker/user/service/UserService.java
@@ -43,12 +43,11 @@ public class UserService {
     }
 
     public User getLoggedInUser() {
-        var principal = getPrincipal();
-        return getUserById(principal.getName());
+        return getUserById(visitingUserId());
     }
 
-    private KeycloakPrincipal getPrincipal() {
-        return (KeycloakPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    private String visitingUserId() {
+        return SecurityContextHolder.getContext().getAuthentication().getName();
     }
 
     private void createUser(Authentication authentication) {

--- a/src/test/java/de/adesso/kicker/user/UserServiceTest.java
+++ b/src/test/java/de/adesso/kicker/user/UserServiceTest.java
@@ -112,13 +112,11 @@ class UserServiceTest {
         var expected = createUser();
         var authentication = mock(Authentication.class);
         var securityContext = mock(SecurityContext.class);
-        var principal = mock(KeycloakPrincipal.class);
         SecurityContextHolder.setContext(securityContext);
 
         when(securityContext.getAuthentication()).thenReturn(authentication);
-        when(authentication.getPrincipal()).thenReturn(principal);
-        when(principal.getName()).thenReturn(expected.getUserId());
-        when(userRepository.findById(anyString())).thenReturn(Optional.of(expected));
+        when(authentication.getName()).thenReturn(expected.getUserId());
+        when(userRepository.findById(expected.getUserId())).thenReturn(Optional.of(expected));
 
         // when
         var actual = userService.getLoggedInUser();


### PR DESCRIPTION
In the process of fixing the method it has been rename to `visitingUserId()` and
now returns the id of the user. If a user is not logged in the id is
`anonymousUser` and will thus cause a `UserNotFoundException` as this user does
not exist. This case has been handled in `ranking()` in `HomeController`.
This closes #98.