### PR TITLE
Fix VerifyMatchRequests trying to delete users

### DIFF
--- a/src/main/java/de/adesso/kicker/match/service/MatchService.java
+++ b/src/main/java/de/adesso/kicker/match/service/MatchService.java
@@ -8,6 +8,7 @@ import de.adesso.kicker.match.exception.InvalidCreatorException;
 import de.adesso.kicker.match.exception.SamePlayerException;
 import de.adesso.kicker.match.persistence.Match;
 import de.adesso.kicker.match.persistence.MatchRepository;
+import de.adesso.kicker.ranking.service.RankingService;
 import de.adesso.kicker.user.persistence.User;
 import de.adesso.kicker.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,13 +26,16 @@ public class MatchService {
 
     private final UserService userService;
 
+    private final RankingService rankingService;
+
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Autowired
-    public MatchService(MatchRepository matchRepository, UserService userService,
+    public MatchService(MatchRepository matchRepository, UserService userService, RankingService rankingService,
             ApplicationEventPublisher applicationEventPublisher) {
         this.matchRepository = matchRepository;
         this.userService = userService;
+        this.rankingService = rankingService;
         this.applicationEventPublisher = applicationEventPublisher;
     }
 
@@ -77,6 +81,7 @@ public class MatchService {
         for (User loser : match.getLosers()) {
             loser.increaseLosses();
         }
+        rankingService.updateRatings(match);
     }
 
     private void checkSamePlayer(Match match) {

--- a/src/main/java/de/adesso/kicker/notification/persistence/Notification.java
+++ b/src/main/java/de/adesso/kicker/notification/persistence/Notification.java
@@ -12,9 +12,9 @@ public abstract class Notification {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long notificationId;
 
-    @OneToOne(targetEntity = User.class, cascade = CascadeType.ALL)
+    @OneToOne
     private User sender;
-    @OneToOne(targetEntity = User.class, cascade = CascadeType.ALL)
+    @OneToOne
     private User receiver;
 
     private LocalDate sendDate;

--- a/src/test/java/de/adesso/kicker/match/MatchServiceTest.java
+++ b/src/test/java/de/adesso/kicker/match/MatchServiceTest.java
@@ -9,6 +9,7 @@ import de.adesso.kicker.match.exception.SamePlayerException;
 import de.adesso.kicker.match.persistence.Match;
 import de.adesso.kicker.match.persistence.MatchRepository;
 import de.adesso.kicker.match.service.MatchService;
+import de.adesso.kicker.ranking.service.RankingService;
 import de.adesso.kicker.user.service.UserService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +35,9 @@ class MatchServiceTest {
 
     @Mock
     private UserService userService;
+
+    @Mock
+    private RankingService rankingService;
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
@@ -107,6 +111,7 @@ class MatchServiceTest {
         // then
         assertTrue(match.isVerified());
         verify(matchRepository, times(1)).save(match);
+        verify(rankingService, times(1)).updateRatings(match);
     }
 
     @ParameterizedTest

--- a/src/test/java/de/adesso/kicker/ranking/RankingServiceTest.java
+++ b/src/test/java/de/adesso/kicker/ranking/RankingServiceTest.java
@@ -1,6 +1,6 @@
 package de.adesso.kicker.ranking;
 
-import de.adesso.kicker.events.MatchVerifiedEventDummy;
+import de.adesso.kicker.match.MatchDummy;
 import de.adesso.kicker.ranking.persistence.Ranking;
 import de.adesso.kicker.ranking.persistence.RankingRepository;
 import de.adesso.kicker.ranking.service.RankingService;
@@ -35,11 +35,10 @@ class RankingServiceTest {
     @DisplayName("When players with a rating of 1500 play their rating should change by 16")
     void ratingsShouldChangeBy16() {
         // given
-        var matchVerifiedEvent = MatchVerifiedEventDummy.matchVerifiedEventLowRanking();
-        var match = matchVerifiedEvent.getMatch();
+        var match = MatchDummy.matchWithLowRating();
 
         // when
-        rankingService.updateRatings(matchVerifiedEvent);
+        rankingService.updateRatings(match);
 
         // then
         assertRating(match.getWinners(), 1516);
@@ -50,11 +49,10 @@ class RankingServiceTest {
     @DisplayName("When players with a rating of 2100 play their rating should change by 12")
     void ratingsShouldChangeBy12() {
         // given
-        var matchVerifiedEvent = MatchVerifiedEventDummy.matchVerifiedEventHighRanking();
-        var match = matchVerifiedEvent.getMatch();
+        var match = MatchDummy.matchWithHighRating();
 
         // when
-        rankingService.updateRatings(matchVerifiedEvent);
+        rankingService.updateRatings(match);
 
         // then
         assertRating(match.getWinners(), 2112);
@@ -65,11 +63,10 @@ class RankingServiceTest {
     @DisplayName("When players with a rating of 2400 play their rating should change by 8")
     void ratingsShouldChangeBy8() {
         // given
-        var matchVerifiedEvent = MatchVerifiedEventDummy.matchVerifiedEventVeryHighRanking();
-        var match = matchVerifiedEvent.getMatch();
+        var match = MatchDummy.matchWithVeryHighRating();
 
         // when
-        rankingService.updateRatings(matchVerifiedEvent);
+        rankingService.updateRatings(match);
 
         // then
         assertRating(match.getWinners(), 2408);
@@ -80,28 +77,15 @@ class RankingServiceTest {
     @DisplayName("When to players in different rating ranges play each players respective k Factor")
     void shouldUseEachPlayersKFactor() {
         // given
-        var matchVerifiedEvent = MatchVerifiedEventDummy.matchVerifiedEventPlayersDifferentRankingRanges();
-        var match = matchVerifiedEvent.getMatch();
+        var match = MatchDummy.matchWithPlayersInDifferentRatingRanges();
         when(rankingRepository.save(any(Ranking.class))).thenReturn(new Ranking());
 
         // when
-        rankingService.updateRatings(matchVerifiedEvent);
+        rankingService.updateRatings(match);
 
         // then
         assertRating(match.getWinners(), 2402);
         assertRating(match.getLosers(), 2096);
-    }
-
-    @Test
-    void verifyAllRatingsAreUpdated() {
-        // given
-        var matchVerifiedEvent = MatchVerifiedEventDummy.matchVerifiedEvent();
-
-        // when
-        rankingService.updateRatings(matchVerifiedEvent);
-
-        // then
-        verify(rankingRepository, times(2)).saveAll(any(List.class));
     }
 
     private static void assertRating(List<User> players, int expected) {


### PR DESCRIPTION
While dealing with `VerifyMatchRequests` users were attempted to be deleted due
to wrong JPA annotations on `sender` and `receiver`. This caused a SQL error.
Additionally `verifyMatch()` now also calls `updateRatings()` in
`RankingService` so all match related updates are in one chain.