### PR TITLE
Update 'MatchControllerTest' to properly test 'MatchController'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,4 @@ $RECYCLE.BIN/
 /kicker.iml
 /src/main/resources/application-dev.properties
 /.idea/.name
+.idea/*

--- a/src/test/java/de/adesso/kicker/match/MatchControllerTest.java
+++ b/src/test/java/de/adesso/kicker/match/MatchControllerTest.java
@@ -1,6 +1,9 @@
 package de.adesso.kicker.match;
 
 import de.adesso.kicker.match.controller.MatchController;
+import de.adesso.kicker.match.exception.FutureDateException;
+import de.adesso.kicker.match.exception.InvalidCreatorException;
+import de.adesso.kicker.match.exception.SamePlayerException;
 import de.adesso.kicker.match.persistence.Match;
 import de.adesso.kicker.match.service.MatchService;
 import de.adesso.kicker.user.persistence.User;
@@ -18,9 +21,10 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(value = MatchController.class, secure = false)
@@ -35,6 +39,10 @@ class MatchControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    private static User createUser() {
+        return UserDummy.defaultUser();
+    }
+
     private static List<User> createUserList() {
         return Arrays.asList(UserDummy.defaultUser(), UserDummy.alternateUser());
     }
@@ -44,7 +52,7 @@ class MatchControllerTest {
     @WithMockUser
     void getAddMatch() throws Exception {
         // given
-        var user = UserDummy.defaultUser();
+        var user = createUser();
         var userList = createUserList();
         when(userService.getAllUsers()).thenReturn(userList);
         when(userService.getLoggedInUser()).thenReturn(user);
@@ -65,18 +73,23 @@ class MatchControllerTest {
     @WithMockUser
     void whenMatchWithOutDateThenReturnNoDate() throws Exception {
         // given
-        var user = UserDummy.defaultUser();
+        var user = createUser();
         var userList = createUserList();
         when(userService.getAllUsers()).thenReturn(userList);
         when(userService.getLoggedInUser()).thenReturn(user);
 
         // when
-        var result = this.mockMvc.perform(post("/matches/add").param("teamAPlayer1", "user")
-                .param("teamBPlayer1", "user2")
+        var result = this.mockMvc.perform(post("/matches/add").param("teamAPlayer1.userId", "user")
+                .param("teamBPlayer1.userId", "user2")
                 .param("winnerTeamA", "true"));
 
         // then
-        result.andExpect(model().attributeExists("noDate"));
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("noDate"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("users", userList));
+        verify(matchService, times(0)).addMatchEntry(any(Match.class));
     }
 
     @Test
@@ -84,25 +97,31 @@ class MatchControllerTest {
     @WithMockUser
     void whenMatchWithNoWinnerThenReturnNoWinner() throws Exception {
         // given
-        var user = UserDummy.defaultUser();
+        var user = createUser();
         var userList = createUserList();
         when(userService.getAllUsers()).thenReturn(userList);
         when(userService.getLoggedInUser()).thenReturn(user);
 
         // when
         var result = mockMvc.perform(post("/matches/add").param("date", LocalDate.now().toString())
-                .param("teamAPlayer1", "user")
-                .param("teamBPlayer1", "user2"));
+                .param("teamAPlayer1.userId", "user")
+                .param("teamBPlayer1.userId", "user2"));
 
         // then
-        result.andExpect(model().attributeExists("noWinner"));
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("noWinner"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("users", userList));
+        verify(matchService, times(0)).addMatchEntry(any(Match.class));
     }
 
     @Test
+    @DisplayName("When no players have been selected 'nullPlayer' should exist")
     @WithMockUser
     void whenMatchWithNoPlayersThenReturnNullPlayers() throws Exception {
         // given
-        var user = UserDummy.defaultUser();
+        var user = createUser();
         var userList = createUserList();
         when(userService.getAllUsers()).thenReturn(userList);
         when(userService.getLoggedInUser()).thenReturn(user);
@@ -112,7 +131,158 @@ class MatchControllerTest {
                 .perform(post("/matches/add").param("date", LocalDate.now().toString()).param("winnerTeamA", "true"));
 
         // then
-        result.andExpect(model().attributeExists("nullPlayer"));
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("nullPlayer"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("users", userList));
+        verify(matchService, times(0)).addMatchEntry(any(Match.class));
     }
 
+    @Test
+    @DisplayName("When only 'teamAPlayer1' has been selected 'nullPlayer' should exist")
+    @WithMockUser
+    void whenMatchWithNoPlayerB1ThenReturnNullPlayers() throws Exception {
+        // given
+        var user = createUser();
+        var userList = createUserList();
+        when(userService.getAllUsers()).thenReturn(userList);
+        when(userService.getLoggedInUser()).thenReturn(user);
+
+        // when
+        var result = mockMvc.perform(post("/matches/add").param("date", LocalDate.now().toString())
+                .param("teamAPlayer1.userId", "user")
+                .param("winnerTeamA", "true"));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("nullPlayer"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("users", userList));
+    }
+
+    @Test
+    @DisplayName("When only 'teamBPlayer1' has been selected 'nullPlayer' should exist")
+    @WithMockUser
+    void whenMatchWithNoPlayerA1ThenReturnNullPlayers() throws Exception {
+        // given
+        var user = createUser();
+        var userList = createUserList();
+        when(userService.getAllUsers()).thenReturn(userList);
+        when(userService.getLoggedInUser()).thenReturn(user);
+
+        // when
+        var result = mockMvc.perform(post("/matches/add").param("date", LocalDate.now().toString())
+                .param("teamBPlayer1.userId", "user2")
+                .param("winnerTeamA", "true"));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("nullPlayer"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("users", userList));
+        verify(matchService, times(0)).addMatchEntry(any(Match.class));
+    }
+
+    @Test
+    @DisplayName("When a valid match is entered expect 'successMessage' and called service")
+    @WithMockUser
+    void whenMatchValidThenReturnSuccessMessage() throws Exception {
+        // given
+        var user = createUser();
+        var userList = createUserList();
+        when(userService.getAllUsers()).thenReturn(userList);
+        when(userService.getLoggedInUser()).thenReturn(user);
+
+        // when
+        var result = mockMvc.perform(post("/matches/add").param("date", LocalDate.now().toString())
+                .param("teamAPlayer1.userId", "user")
+                .param("teamBPlayer1.userId", "user2")
+                .param("winnerTeamA", "true"));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("successMessage"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("users", userList));
+        verify(matchService, times(1)).addMatchEntry(any(Match.class));
+    }
+
+    @Test
+    @DisplayName("When 'FutureDateException' is thrown expect 'futureDate'")
+    @WithMockUser
+    void expectFutureDate() throws Exception {
+        // given
+        var user = createUser();
+        var userList = createUserList();
+        when(userService.getAllUsers()).thenReturn(userList);
+        when(userService.getLoggedInUser()).thenReturn(user);
+        doThrow(FutureDateException.class).when(matchService).addMatchEntry(any(Match.class));
+
+        // when
+        var result = mockMvc.perform(post("/matches/add").param("date", LocalDate.now().plusDays(1).toString())
+                .param("teamAPlayer1.userId", "user")
+                .param("teamBPlayer1.userId", "user2")
+                .param("winnerTeamA", "true"));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("futureDate"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("users", userList));
+    }
+
+    @Test
+    @DisplayName("When 'InvalidCreatorException' is thrown expect 'invalidCreator'")
+    @WithMockUser
+    void expectInvalidCreator() throws Exception {
+        // given
+        var user = createUser();
+        var userList = createUserList();
+        when(userService.getAllUsers()).thenReturn(userList);
+        when(userService.getLoggedInUser()).thenReturn(user);
+        doThrow(InvalidCreatorException.class).when(matchService).addMatchEntry(any(Match.class));
+
+        // when
+        var result = mockMvc.perform(post("/matches/add").param("date", LocalDate.now().plusDays(1).toString())
+                .param("teamAPlayer1.userId", "user")
+                .param("teamBPlayer1.userId", "user2")
+                .param("winnerTeamA", "true"));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("invalidCreator"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("users", userList));
+    }
+
+    @Test
+    @DisplayName("When 'SamePlayerException' is thrown expect 'samePlayer'")
+    @WithMockUser
+    void expectSamePlayer() throws Exception {
+        // given
+        var user = createUser();
+        var userList = createUserList();
+        when(userService.getAllUsers()).thenReturn(userList);
+        when(userService.getLoggedInUser()).thenReturn(user);
+        doThrow(SamePlayerException.class).when(matchService).addMatchEntry(any(Match.class));
+
+        // when
+        var result = mockMvc.perform(post("/matches/add").param("date", LocalDate.now().plusDays(1).toString())
+                .param("teamAPlayer1.userId", "user")
+                .param("teamBPlayer1.userId", "user2")
+                .param("winnerTeamA", "true"));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("samePlayer"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("users", userList));
+    }
 }

--- a/src/test/java/de/adesso/kicker/match/MatchDummy.java
+++ b/src/test/java/de/adesso/kicker/match/MatchDummy.java
@@ -18,8 +18,8 @@ public class MatchDummy {
     }
 
     public static Match matchWithEqualPlayerA1B2() {
-        return new Match(LocalDate.now(), UserDummy.defaultUser(), UserDummy.alternateUser(), UserDummy.defaultUser(),
-                UserDummy.alternateUser2(), true);
+        return new Match(LocalDate.now(), UserDummy.defaultUser(), UserDummy.alternateUser(),
+                UserDummy.alternateUser2(), UserDummy.defaultUser(), true);
     }
 
     public static Match matchWithEqualPlayerA2B2() {


### PR DESCRIPTION
Previously it was only tested whether the error messages would appear as the
users have never been sent to the Controller.
This has been fixed by accessing the nested `userId` field and setting it on
the neccessary fields.
The tests now also check if the controller methods properly handle the
exceptions thrown by `MatchService`