### PR TITLE
Fix ressources not being found on some sites

### DIFF
--- a/src/main/resources/templates/sites/matchresult.html
+++ b/src/main/resources/templates/sites/matchresult.html
@@ -25,11 +25,11 @@
   <!-- Fontawesome -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.0/css/all.css">
   <!-- Hover CSS -->
-  <link rel="stylesheet" type="text/css" href="../css/hover-min.css">
+  <link rel="stylesheet" type="text/css" href="/css/hover-min.css">
 
   <!-- My stylesheets -->
-  <link rel="stylesheet/less" type="text/css" href="../css/header.less">
-  <link rel="stylesheet/less" type="text/css" href="../css/matchresult.less">
+  <link rel="stylesheet/less" type="text/css" href="/css/header.less">
+  <link rel="stylesheet/less" type="text/css" href="/css/matchresult.less">
   <!-- LESS -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/3.9.0/less.min.js"></script>
 </head>

--- a/src/main/resources/templates/sites/profile.html
+++ b/src/main/resources/templates/sites/profile.html
@@ -17,11 +17,11 @@
   <!-- Fontawesome -->
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.0/css/all.css">
   <!-- Hover CSS -->
-  <link rel="stylesheet" type="text/css" href="../css/hover-min.css">
+  <link rel="stylesheet" type="text/css" href="/css/hover-min.css">
 
   <!-- My stylesheets -->
-  <link rel="stylesheet/less" type="text/css" href="../css/header.less">
-  <link rel="stylesheet/less" type="text/css" href="../css/profile.less">
+  <link rel="stylesheet/less" type="text/css" href="/css/header.less">
+  <link rel="stylesheet/less" type="text/css" href="/css/profile.less">
   <!-- LESS -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/3.9.0/less.min.js"></script>
 </head>

--- a/src/main/resources/templates/sites/ranking.html
+++ b/src/main/resources/templates/sites/ranking.html
@@ -20,11 +20,11 @@
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.0/css/all.css">
 
   <!-- Hover CSS -->
-  <link rel="stylesheet" type="text/css" href="../css/hover-min.css">
+  <link rel="stylesheet" type="text/css" href="/css/hover-min.css">
 
   <!-- My stylesheets -->
-  <link rel="stylesheet/less" type="text/css" href="../css/header.less">
-  <link rel="stylesheet/less" type="text/css" href="../css/ranking.less">
+  <link rel="stylesheet/less" type="text/css" href="/css/header.less">
+  <link rel="stylesheet/less" type="text/css" href="/css/ranking.less">
 
   <!-- LESS -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/3.9.0/less.min.js"></script>


### PR DESCRIPTION
The ressources were linked with relative paths which caused them not to be found
when the site has been moved.
To fix this the ressources are now linked with the full paths.