### PR TITLE
Fix UserNotFoundException being thrown on /users/u/{id}

### DIFF
--- a/src/main/java/de/adesso/kicker/user/controller/UserController.java
+++ b/src/main/java/de/adesso/kicker/user/controller/UserController.java
@@ -2,6 +2,7 @@ package de.adesso.kicker.user.controller;
 
 import de.adesso.kicker.notification.service.NotificationService;
 import de.adesso.kicker.ranking.service.RankingService;
+import de.adesso.kicker.user.exception.UserNotFoundException;
 import de.adesso.kicker.user.persistence.User;
 import de.adesso.kicker.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,7 @@ public class UserController {
 
     @GetMapping("/you")
     public ModelAndView getOwnProfile() {
-        ModelAndView modelAndView = new ModelAndView();
+        var modelAndView = new ModelAndView();
         var user = userService.getLoggedInUser();
         return defaultProfileView(modelAndView, user);
     }
@@ -40,8 +41,12 @@ public class UserController {
         var rankingPosition = rankingService.getPositionOfPlayer(user.getRanking());
         modelAndView.addObject("user", user);
         modelAndView.addObject("rankingPosition", rankingPosition);
-        modelAndView.addObject("notifications",
-                notificationService.getNotificationsByReceiver(userService.getLoggedInUser()));
+        try {
+            var notifications = notificationService.getNotificationsByReceiver(userService.getLoggedInUser());
+            modelAndView.addObject("notifications", notifications);
+        } catch (UserNotFoundException e) {
+            modelAndView.addObject("notifications", false);
+        }
         modelAndView.setViewName("sites/profile.html");
         return modelAndView;
     }


### PR DESCRIPTION
The exception was thrown for not logged in users because the
controller tried to get the notifications for anonymousUser. This user
doesn't exist and thus findUserById threw the UserNotFoundException.
And because it wasn't caught it showed users the error page.