### PR TITLE
Add max attribute to date input field in /matchresult.html

### DIFF
--- a/src/main/resources/templates/sites/matchresult.html
+++ b/src/main/resources/templates/sites/matchresult.html
@@ -167,7 +167,7 @@
     </div>
     <div class="form-group" id="datetimepicker-form-group">
       <div class="input-group date">
-        <input type="date" th:field="*{date}" id="datetimepicker" class="form-control"/>
+        <input type="date" th:field="*{date}" id="datetimepicker" class="form-control" th:max="${#dates.format(#dates.createNow(), 'yyyy-MM-dd')}">
         <div class="input-group-append">
           <div class="input-group-text"><i class="fa fa-calendar"></i></div>
         </div>


### PR DESCRIPTION
This helps to prevent user from accidentally or maybe intentionally
entering a date in the future. This also makes it clearer that one
can't select a future date.
Closes #215 