### PR TITLE
Change check for logged in user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,4 @@ $RECYCLE.BIN/
 /src/main/resources/application-dev.properties
 /.idea/.name
 .idea/*
+.attach_pid*

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
   <title>adesso kicker</title>
 
@@ -58,7 +58,7 @@
       </ul>
     </div>
     <!-- Notification Dropdown -->
-    <div class="dropdown ml-auto" id="notification-dropdown" th:if="${#authentication.getName() != 'anonymousUser'}">
+    <div class="dropdown ml-auto" id="notification-dropdown" sec:authorize="isAuthenticated()">
       <button onblur="toggleEnvelope()" onfocus="toggleEnvelope()"
               type="button" class="btn header-dropdown-bt hvr-fade" id="notification-dropdown-icon"
               data-toggle="dropdown">
@@ -82,11 +82,11 @@
         </div>
       </div>
     </div>
-    <div th:if="${#authentication.getName() == 'anonymousUser'}">
+    <div sec:authorize="!isAuthenticated()">
       <a type="button" class="btn btn-primary hvr-fade" id="login-button" href="/sso/login" th:text="#{sites.login}"></a>
     </div>
     <!-- Profile Settings -->
-    <div class="dropdown ml-auto" id="profile-dropdown" th:if="${#authentication.getName() != 'anonymousUser'}">
+    <div class="dropdown ml-auto" id="profile-dropdown" sec:authorize="isAuthenticated()">
       <button type="button" class="btn dropdown-toggle header-dropdown-bt hvr-fade" data-toggle="dropdown">
         <!-- User Name -->
         <span th:text="${#authentication.getName()}"></span>

--- a/src/main/resources/templates/sites/ranking.html
+++ b/src/main/resources/templates/sites/ranking.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
   <title>adesso kicker</title>
   <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -121,7 +121,8 @@
       </tr>
       <!-- Logged-In User -->
       <tr class="user-table-row"
-          th:if="${#authentication.getName() != 'anonymousUser' && !users.contains(user)}"
+          sec:authorize="isAuthenticated()"
+          th:if="${!users.contains(user)}"
           th:href="@{/users/u/{id}(id=${user.userId})}"
           onclick="window.location.href=this.getAttribute('href')" id="user-self">
         <td>

--- a/src/test/java/de/adesso/kicker/match/MatchControllerTest.java
+++ b/src/test/java/de/adesso/kicker/match/MatchControllerTest.java
@@ -14,10 +14,13 @@ import de.adesso.kicker.user.persistence.User;
 import de.adesso.kicker.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.keycloak.adapters.springboot.KeycloakAutoConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
@@ -31,7 +34,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(value = MatchController.class, secure = false)
+@TestPropertySource("classpath:application-test.properties")
+@Import(KeycloakAutoConfiguration.class)
+@WebMvcTest(value = MatchController.class)
 class MatchControllerTest {
 
     @MockBean

--- a/src/test/java/de/adesso/kicker/notification/NotificationControllerTest.java
+++ b/src/test/java/de/adesso/kicker/notification/NotificationControllerTest.java
@@ -8,10 +8,13 @@ import de.adesso.kicker.notification.service.NotificationService;
 import de.adesso.kicker.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.keycloak.adapters.springboot.KeycloakAutoConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -22,8 +25,10 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@WebMvcTest(value = NotificationController.class, secure = false)
-public class NotificationControllerTest {
+@TestPropertySource("classpath:application-test.properties")
+@Import(KeycloakAutoConfiguration.class)
+@WebMvcTest(value = NotificationController.class)
+class NotificationControllerTest {
 
     @MockBean
     NotificationService notificationService;

--- a/src/test/java/de/adesso/kicker/user/UserControllerTest.java
+++ b/src/test/java/de/adesso/kicker/user/UserControllerTest.java
@@ -8,10 +8,15 @@ import de.adesso.kicker.user.exception.UserNotFoundException;
 import de.adesso.kicker.user.persistence.User;
 import de.adesso.kicker.user.service.UserService;
 import org.junit.jupiter.api.Test;
+import org.keycloak.adapters.springboot.KeycloakAutoConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -25,7 +30,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = UserController.class, secure = false)
+@TestPropertySource("classpath:application-test.properties")
+@Import(KeycloakAutoConfiguration.class)
+@WebMvcTest(value = UserController.class)
 class UserControllerTest {
 
     @Autowired
@@ -82,7 +89,7 @@ class UserControllerTest {
     }
 
     @Test
-    @WithMockUser("anonymousUser")
+    @WithAnonymousUser
     void whenUserExistsReturnUserLoggedOut() throws Exception {
         // given
         var user = UserDummy.defaultUser();

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,5 @@
+keycloak.auth-server-url=localhost
+keycloak.realm=test
+keycloak.resource=kicker
+keycloak.public-client=true
+keycloak.principal-attribute=preferred_username


### PR DESCRIPTION
Previously it was checked whether a user is logged in or not by
comparing the name to 'anonymousUser'. This was problematic while
testing and in the off chance a user with this name would register.
To circumvent this we now check whether a user is authenticated or not
by using `sec:authorize="isAuthenticated()"` which is part of the
`thymeleaf-extras-springsecurity` dependency.
This has replaced the old check in `header.html` and `ranking.html`
which should have been all uses unless any were overlooked.
With this change the tests had to be updated because due to the old
setup the tests would fail as security was disabled during the tests.
So to make the tests work security was enabled which caused the tests
to fail again because Keycloak would cause a `NullPointerException` due
to `AdapterConfig` null. To fix this all tests for the web layer now
import `KeycloakAutoConfiguration.class` to properly initialize
Keycloak in the Spring Context for the tests.