### PR TITLE
Tracks ranks over time

### DIFF
--- a/src/main/java/de/adesso/kicker/Application.java
+++ b/src/main/java/de/adesso/kicker/Application.java
@@ -2,8 +2,10 @@ package de.adesso.kicker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);

--- a/src/main/java/de/adesso/kicker/match/service/MatchService.java
+++ b/src/main/java/de/adesso/kicker/match/service/MatchService.java
@@ -8,7 +8,7 @@ import de.adesso.kicker.match.exception.InvalidCreatorException;
 import de.adesso.kicker.match.exception.SamePlayerException;
 import de.adesso.kicker.match.persistence.Match;
 import de.adesso.kicker.match.persistence.MatchRepository;
-import de.adesso.kicker.ranking.service.RankingService;
+import de.adesso.kicker.statistics.ranking.service.RankingService;
 import de.adesso.kicker.user.persistence.User;
 import de.adesso.kicker.user.service.UserService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/de/adesso/kicker/statistics/ranking/persistence/Ranking.java
+++ b/src/main/java/de/adesso/kicker/statistics/ranking/persistence/Ranking.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.ranking.persistence;
+package de.adesso.kicker.statistics.ranking.persistence;
 
 import lombok.Data;
 

--- a/src/main/java/de/adesso/kicker/statistics/ranking/persistence/RankingRepository.java
+++ b/src/main/java/de/adesso/kicker/statistics/ranking/persistence/RankingRepository.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.ranking.persistence;
+package de.adesso.kicker.statistics.ranking.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/de/adesso/kicker/statistics/ranking/service/KFactor.java
+++ b/src/main/java/de/adesso/kicker/statistics/ranking/service/KFactor.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.ranking.service;
+package de.adesso.kicker.statistics.ranking.service;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/de/adesso/kicker/statistics/ranking/service/Outcome.java
+++ b/src/main/java/de/adesso/kicker/statistics/ranking/service/Outcome.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.ranking.service;
+package de.adesso.kicker.statistics.ranking.service;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/de/adesso/kicker/statistics/ranking/service/RankingService.java
+++ b/src/main/java/de/adesso/kicker/statistics/ranking/service/RankingService.java
@@ -1,8 +1,8 @@
-package de.adesso.kicker.ranking.service;
+package de.adesso.kicker.statistics.ranking.service;
 
 import de.adesso.kicker.match.persistence.Match;
-import de.adesso.kicker.ranking.persistence.Ranking;
-import de.adesso.kicker.ranking.persistence.RankingRepository;
+import de.adesso.kicker.statistics.ranking.persistence.RankingRepository;
+import de.adesso.kicker.statistics.ranking.persistence.Ranking;
 import de.adesso.kicker.user.persistence.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/de/adesso/kicker/statistics/ranking/service/RatingRange.java
+++ b/src/main/java/de/adesso/kicker/statistics/ranking/service/RatingRange.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.ranking.service;
+package de.adesso.kicker.statistics.ranking.service;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/de/adesso/kicker/statistics/trackedranking/persistence/TrackedRanking.java
+++ b/src/main/java/de/adesso/kicker/statistics/trackedranking/persistence/TrackedRanking.java
@@ -1,0 +1,37 @@
+package de.adesso.kicker.statistics.trackedranking.persistence;
+
+import de.adesso.kicker.user.persistence.User;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@Entity
+public class TrackedRanking {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private String rankingId;
+
+    private int rank;
+
+    private int rating;
+
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne
+    private User user;
+
+    private LocalDate date;
+
+    public TrackedRanking(int rank, int rating, User user) {
+        this.rank = rank;
+        this.rating = rating;
+        this.user = user;
+        this.date = LocalDate.now();
+    }
+}

--- a/src/main/java/de/adesso/kicker/statistics/trackedranking/persistence/TrackedRankingRepository.java
+++ b/src/main/java/de/adesso/kicker/statistics/trackedranking/persistence/TrackedRankingRepository.java
@@ -1,0 +1,10 @@
+package de.adesso.kicker.statistics.trackedranking.persistence;
+
+import de.adesso.kicker.user.persistence.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TrackedRankingRepository extends JpaRepository<TrackedRanking, String> {
+    List<TrackedRanking> findAllByUser(User user);
+}

--- a/src/main/java/de/adesso/kicker/statistics/trackedranking/service/TrackedRankingService.java
+++ b/src/main/java/de/adesso/kicker/statistics/trackedranking/service/TrackedRankingService.java
@@ -1,0 +1,44 @@
+package de.adesso.kicker.statistics.trackedranking.service;
+
+import de.adesso.kicker.statistics.trackedranking.persistence.TrackedRanking;
+import de.adesso.kicker.statistics.trackedranking.persistence.TrackedRankingRepository;
+import de.adesso.kicker.user.persistence.User;
+import de.adesso.kicker.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+class TrackedRankingService {
+
+    private final UserService userService;
+
+    private final TrackedRankingRepository trackedRankingRepository;
+
+    private final Logger logger = LoggerFactory.getLogger(TrackedRankingService.class);
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    void trackRankings() {
+        var users = userService.getAllUsersWithRank();
+        var trackedRankings = users.stream().map(user -> {
+            var ranking = user.getRanking();
+            var rank = ranking.getRank();
+            var rating = ranking.getRating();
+            return new TrackedRanking(rank, rating, user);
+        }).collect(Collectors.toList());
+        trackedRankingRepository.saveAll(trackedRankings);
+        logger.info("Tracked rankings of {} users", users.size());
+    }
+
+    public List<TrackedRanking> getTrackedRankingsByUser(User user) {
+        return trackedRankingRepository.findAllByUser(user);
+    }
+}

--- a/src/main/java/de/adesso/kicker/user/persistence/User.java
+++ b/src/main/java/de/adesso/kicker/user/persistence/User.java
@@ -1,6 +1,6 @@
 package de.adesso.kicker.user.persistence;
 
-import de.adesso.kicker.ranking.persistence.Ranking;
+import de.adesso.kicker.statistics.ranking.persistence.Ranking;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/src/test/java/de/adesso/kicker/match/MatchServiceTest.java
+++ b/src/test/java/de/adesso/kicker/match/MatchServiceTest.java
@@ -9,7 +9,7 @@ import de.adesso.kicker.match.exception.SamePlayerException;
 import de.adesso.kicker.match.persistence.Match;
 import de.adesso.kicker.match.persistence.MatchRepository;
 import de.adesso.kicker.match.service.MatchService;
-import de.adesso.kicker.ranking.service.RankingService;
+import de.adesso.kicker.statistics.ranking.service.RankingService;
 import de.adesso.kicker.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/de/adesso/kicker/statistics/ranking/RankingDummy.java
+++ b/src/test/java/de/adesso/kicker/statistics/ranking/RankingDummy.java
@@ -1,6 +1,6 @@
-package de.adesso.kicker.ranking;
+package de.adesso.kicker.statistics.ranking;
 
-import de.adesso.kicker.ranking.persistence.Ranking;
+import de.adesso.kicker.statistics.ranking.persistence.Ranking;
 
 public class RankingDummy {
     public static Ranking ranking() {

--- a/src/test/java/de/adesso/kicker/statistics/ranking/RankingServiceTest.java
+++ b/src/test/java/de/adesso/kicker/statistics/ranking/RankingServiceTest.java
@@ -1,10 +1,11 @@
-package de.adesso.kicker.ranking;
+package de.adesso.kicker.statistics.ranking;
 
 import de.adesso.kicker.match.MatchDummy;
-import de.adesso.kicker.ranking.persistence.Ranking;
-import de.adesso.kicker.ranking.persistence.RankingRepository;
-import de.adesso.kicker.ranking.service.RankingService;
+import de.adesso.kicker.statistics.ranking.persistence.Ranking;
+import de.adesso.kicker.statistics.ranking.persistence.RankingRepository;
+import de.adesso.kicker.statistics.ranking.service.RankingService;
 import de.adesso.kicker.user.persistence.User;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -125,7 +126,7 @@ class RankingServiceTest {
     private static void assertRatingPlayers(int expected, List<User> players) {
         for (var player : players) {
             var actual = player.getRanking().getRating();
-            assertEquals(expected, actual);
+            Assertions.assertEquals(expected, actual);
         }
     }
 }

--- a/src/test/java/de/adesso/kicker/user/UserDummy.java
+++ b/src/test/java/de/adesso/kicker/user/UserDummy.java
@@ -1,6 +1,6 @@
 package de.adesso.kicker.user;
 
-import de.adesso.kicker.ranking.RankingDummy;
+import de.adesso.kicker.statistics.ranking.RankingDummy;
 import de.adesso.kicker.user.persistence.User;
 
 public class UserDummy {

--- a/src/test/java/de/adesso/kicker/user/UserServiceTest.java
+++ b/src/test/java/de/adesso/kicker/user/UserServiceTest.java
@@ -1,6 +1,6 @@
 package de.adesso.kicker.user;
 
-import de.adesso.kicker.ranking.service.RankingService;
+import de.adesso.kicker.statistics.ranking.service.RankingService;
 import de.adesso.kicker.user.exception.UserNotFoundException;
 import de.adesso.kicker.user.persistence.User;
 import de.adesso.kicker.user.persistence.UserRepository;


### PR DESCRIPTION
This should be the last bit necessary to be able to show statistics
on a users profile.
Rankings are tracked once a day at 00:00 for all users that have a
ranking. Meaning all users that have played at least one match.