### PR TITLE
Fix responsiveness of ranking-table in ranking.html

### DIFF
--- a/src/main/resources/templates/sites/ranking.html
+++ b/src/main/resources/templates/sites/ranking.html
@@ -76,8 +76,8 @@
 </div>
 <!-- User List -->
 <div class="container-fluid">
-  <div class="shadow-sm" id="table-container" th:if="${allUsers.size()>0}">
-    <table class="user-table table">
+  <div th:if="${allUsers.size()>0}" style="overflow-x:auto;">
+    <table style="width: 80%; margin-left: 10%; border-color: #332f2d" class="user-table table shadow-sm">
       <thead>
       <tr>
         <!-- Rank -->


### PR DESCRIPTION
Table responsiveness was kind of broken. We had two borders: one was
empty and centered the other one was the actual border with data which
stretched the site in general. Now the table is responsive just like you
are used to it from known sites.