### PR TITLE
Remove all circular dependencies

### DIFF
--- a/src/main/java/de/adesso/kicker/email/EmailService.java
+++ b/src/main/java/de/adesso/kicker/email/EmailService.java
@@ -1,7 +1,7 @@
 package de.adesso.kicker.email;
 
-import de.adesso.kicker.events.match.MatchVerificationSentEvent;
 import de.adesso.kicker.match.persistence.Match;
+import de.adesso.kicker.notification.matchverificationrequest.service.events.MatchVerificationSentEvent;
 import de.adesso.kicker.user.persistence.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;

--- a/src/main/java/de/adesso/kicker/match/controller/MatchController.java
+++ b/src/main/java/de/adesso/kicker/match/controller/MatchController.java
@@ -5,7 +5,6 @@ import de.adesso.kicker.match.exception.InvalidCreatorException;
 import de.adesso.kicker.match.exception.SamePlayerException;
 import de.adesso.kicker.match.persistence.Match;
 import de.adesso.kicker.match.service.MatchService;
-import de.adesso.kicker.notification.service.NotificationService;
 import de.adesso.kicker.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
@@ -26,8 +25,6 @@ public class MatchController {
     private final MatchService matchService;
 
     private final UserService userService;
-
-    private final NotificationService notificationService;
 
     @GetMapping("/add")
     public ModelAndView getAddMatch() {
@@ -69,12 +66,10 @@ public class MatchController {
     private ModelAndView defaultAddMatchView(ModelAndView modelAndView) {
         var match = new Match();
         var user = userService.getLoggedInUser();
-        var notifications = notificationService.getNotificationsByReceiver(user);
         var users = userService.getAllUsers();
         modelAndView.addObject("match", match);
         modelAndView.addObject("currentUser", user);
         modelAndView.addObject("users", users);
-        modelAndView.addObject("notifications", notifications);
         modelAndView.setViewName("sites/matchresult.html");
         return modelAndView;
     }

--- a/src/main/java/de/adesso/kicker/match/service/MatchService.java
+++ b/src/main/java/de/adesso/kicker/match/service/MatchService.java
@@ -1,15 +1,14 @@
 package de.adesso.kicker.match.service;
 
-import de.adesso.kicker.events.match.MatchCreatedEvent;
-import de.adesso.kicker.events.match.MatchDeclinedEvent;
-import de.adesso.kicker.events.match.MatchVerifiedEvent;
 import de.adesso.kicker.match.exception.FutureDateException;
 import de.adesso.kicker.match.exception.InvalidCreatorException;
 import de.adesso.kicker.match.exception.SamePlayerException;
 import de.adesso.kicker.match.persistence.Match;
 import de.adesso.kicker.match.persistence.MatchRepository;
-import de.adesso.kicker.statistics.ranking.service.RankingService;
-import de.adesso.kicker.user.persistence.User;
+import de.adesso.kicker.match.service.events.MatchCreatedEvent;
+import de.adesso.kicker.match.service.events.MatchDeclinedEvent;
+import de.adesso.kicker.match.service.events.MatchVerifiedEvent;
+import de.adesso.kicker.user.service.RankingService;
 import de.adesso.kicker.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -70,13 +69,15 @@ public class MatchService {
     }
 
     private void updateStatistics(Match match) {
-        for (User winner : match.getWinners()) {
+        var winners = match.getWinners();
+        var losers = match.getWinners();
+        for (var winner : winners) {
             winner.increaseWins();
         }
-        for (User loser : match.getLosers()) {
+        for (var loser : losers) {
             loser.increaseLosses();
         }
-        rankingService.updateRatings(match);
+        rankingService.updateRatings(winners, losers);
         rankingService.updateRanks();
     }
 

--- a/src/main/java/de/adesso/kicker/match/service/events/MatchCreatedEvent.java
+++ b/src/main/java/de/adesso/kicker/match/service/events/MatchCreatedEvent.java
@@ -1,15 +1,15 @@
-package de.adesso.kicker.events.match;
+package de.adesso.kicker.match.service.events;
 
 import de.adesso.kicker.match.persistence.Match;
 import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class MatchVerifiedEvent extends ApplicationEvent {
+public class MatchCreatedEvent extends ApplicationEvent {
 
     private final Match match;
 
-    public MatchVerifiedEvent(Object source, Match match) {
+    public MatchCreatedEvent(Object source, Match match) {
         super(source);
         this.match = match;
     }

--- a/src/main/java/de/adesso/kicker/match/service/events/MatchDeclinedEvent.java
+++ b/src/main/java/de/adesso/kicker/match/service/events/MatchDeclinedEvent.java
@@ -1,15 +1,15 @@
-package de.adesso.kicker.events.match;
+package de.adesso.kicker.match.service.events;
 
 import de.adesso.kicker.match.persistence.Match;
 import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class MatchCreatedEvent extends ApplicationEvent {
+public class MatchDeclinedEvent extends ApplicationEvent {
 
     private final Match match;
 
-    public MatchCreatedEvent(Object source, Match match) {
+    public MatchDeclinedEvent(Object source, Match match) {
         super(source);
         this.match = match;
     }

--- a/src/main/java/de/adesso/kicker/match/service/events/MatchVerifiedEvent.java
+++ b/src/main/java/de/adesso/kicker/match/service/events/MatchVerifiedEvent.java
@@ -1,15 +1,15 @@
-package de.adesso.kicker.events.match;
+package de.adesso.kicker.match.service.events;
 
 import de.adesso.kicker.match.persistence.Match;
 import lombok.Getter;
 import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class MatchDeclinedEvent extends ApplicationEvent {
+public class MatchVerifiedEvent extends ApplicationEvent {
 
     private final Match match;
 
-    public MatchDeclinedEvent(Object source, Match match) {
+    public MatchVerifiedEvent(Object source, Match match) {
         super(source);
         this.match = match;
     }

--- a/src/main/java/de/adesso/kicker/notification/matchverificationrequest/service/VerifyMatchService.java
+++ b/src/main/java/de/adesso/kicker/notification/matchverificationrequest/service/VerifyMatchService.java
@@ -1,12 +1,12 @@
 package de.adesso.kicker.notification.matchverificationrequest.service;
 
-import de.adesso.kicker.events.match.MatchCreatedEvent;
-import de.adesso.kicker.events.match.MatchDeclinedEvent;
-import de.adesso.kicker.events.match.MatchVerificationSentEvent;
-import de.adesso.kicker.events.match.MatchVerifiedEvent;
 import de.adesso.kicker.match.persistence.Match;
+import de.adesso.kicker.match.service.events.MatchCreatedEvent;
+import de.adesso.kicker.match.service.events.MatchDeclinedEvent;
+import de.adesso.kicker.match.service.events.MatchVerifiedEvent;
 import de.adesso.kicker.notification.matchverificationrequest.persistence.MatchVerificationRequest;
 import de.adesso.kicker.notification.matchverificationrequest.persistence.MatchVerificationRequestRepository;
+import de.adesso.kicker.notification.matchverificationrequest.service.events.MatchVerificationSentEvent;
 import de.adesso.kicker.user.persistence.User;
 import de.adesso.kicker.user.service.UserService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/de/adesso/kicker/notification/matchverificationrequest/service/events/MatchVerificationSentEvent.java
+++ b/src/main/java/de/adesso/kicker/notification/matchverificationrequest/service/events/MatchVerificationSentEvent.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.events.match;
+package de.adesso.kicker.notification.matchverificationrequest.service.events;
 
 import de.adesso.kicker.notification.matchverificationrequest.persistence.MatchVerificationRequest;
 import lombok.Getter;

--- a/src/main/java/de/adesso/kicker/site/controller/HomeController.java
+++ b/src/main/java/de/adesso/kicker/site/controller/HomeController.java
@@ -1,6 +1,5 @@
 package de.adesso.kicker.site.controller;
 
-import de.adesso.kicker.notification.service.NotificationService;
 import de.adesso.kicker.user.exception.UserNotFoundException;
 import de.adesso.kicker.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +14,6 @@ public class HomeController {
 
     private final UserService userService;
 
-    private final NotificationService notificationService;
-
     @GetMapping(value = { "/", "/home", "/ranking" })
     public ModelAndView ranking(@RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
@@ -25,12 +22,9 @@ public class HomeController {
         var allUsers = userService.getAllUsersWithRank();
         try {
             var user = userService.getLoggedInUser();
-            var notifications = notificationService.getNotificationsByReceiver(user);
             modelAndView.addObject("user", user);
-            modelAndView.addObject("notifications", notifications);
         } catch (UserNotFoundException e) {
             modelAndView.addObject("user", false);
-            modelAndView.addObject("notifications", false);
         }
         modelAndView.addObject("users", users);
         modelAndView.addObject("allUsers", allUsers);

--- a/src/main/java/de/adesso/kicker/user/controller/UserController.java
+++ b/src/main/java/de/adesso/kicker/user/controller/UserController.java
@@ -1,7 +1,5 @@
 package de.adesso.kicker.user.controller;
 
-import de.adesso.kicker.notification.service.NotificationService;
-import de.adesso.kicker.user.exception.UserNotFoundException;
 import de.adesso.kicker.user.persistence.User;
 import de.adesso.kicker.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +15,6 @@ import org.springframework.web.servlet.ModelAndView;
 public class UserController {
 
     private final UserService userService;
-
-    private final NotificationService notificationService;
 
     @GetMapping("/u/{id}")
     public ModelAndView getUserProfile(@PathVariable String id) {
@@ -36,13 +32,6 @@ public class UserController {
 
     private ModelAndView defaultProfileView(ModelAndView modelAndView, User user) {
         modelAndView.addObject("user", user);
-        try {
-            var currentUser = userService.getLoggedInUser();
-            var notifications = notificationService.getNotificationsByReceiver(currentUser);
-            modelAndView.addObject("notifications", notifications);
-        } catch (UserNotFoundException e) {
-            modelAndView.addObject("notifications", false);
-        }
         modelAndView.setViewName("sites/profile.html");
         return modelAndView;
     }

--- a/src/main/java/de/adesso/kicker/user/persistence/Ranking.java
+++ b/src/main/java/de/adesso/kicker/user/persistence/Ranking.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.statistics.ranking.persistence;
+package de.adesso.kicker.user.persistence;
 
 import lombok.Data;
 

--- a/src/main/java/de/adesso/kicker/user/persistence/RankingRepository.java
+++ b/src/main/java/de/adesso/kicker/user/persistence/RankingRepository.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.statistics.ranking.persistence;
+package de.adesso.kicker.user.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/de/adesso/kicker/user/persistence/User.java
+++ b/src/main/java/de/adesso/kicker/user/persistence/User.java
@@ -1,6 +1,5 @@
 package de.adesso.kicker.user.persistence;
 
-import de.adesso.kicker.statistics.ranking.persistence.Ranking;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/de/adesso/kicker/user/service/KFactor.java
+++ b/src/main/java/de/adesso/kicker/user/service/KFactor.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.statistics.ranking.service;
+package de.adesso.kicker.user.service;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/de/adesso/kicker/user/service/Outcome.java
+++ b/src/main/java/de/adesso/kicker/user/service/Outcome.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.statistics.ranking.service;
+package de.adesso.kicker.user.service;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/de/adesso/kicker/user/service/RankingService.java
+++ b/src/main/java/de/adesso/kicker/user/service/RankingService.java
@@ -1,8 +1,7 @@
-package de.adesso.kicker.statistics.ranking.service;
+package de.adesso.kicker.user.service;
 
-import de.adesso.kicker.match.persistence.Match;
-import de.adesso.kicker.statistics.ranking.persistence.RankingRepository;
-import de.adesso.kicker.statistics.ranking.persistence.Ranking;
+import de.adesso.kicker.user.persistence.Ranking;
+import de.adesso.kicker.user.persistence.RankingRepository;
 import de.adesso.kicker.user.persistence.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -49,10 +48,7 @@ public class RankingService {
         return rankingRepository.countAllByRatingAfter(ranking.getRating()) + INDEX_OFFSET;
     }
 
-    public void updateRatings(Match match) {
-        var winners = match.getWinners();
-        var losers = match.getLosers();
-
+    public void updateRatings(List<User> winners, List<User> losers) {
         var winnerRating = getTeamRating(winners);
         var loserRating = getTeamRating(losers);
 
@@ -61,6 +57,8 @@ public class RankingService {
 
         applyResultsToTeam(winners, Outcome.WON, expectedWinnerScore);
         applyResultsToTeam(losers, Outcome.LOST, expectedLoserScore);
+
+        updateRanks();
     }
 
     private double expectedScore(int winnerRating, int loserRating) {

--- a/src/main/java/de/adesso/kicker/user/service/RatingRange.java
+++ b/src/main/java/de/adesso/kicker/user/service/RatingRange.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.statistics.ranking.service;
+package de.adesso.kicker.user.service;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/de/adesso/kicker/user/trackedranking/persistence/TrackedRanking.java
+++ b/src/main/java/de/adesso/kicker/user/trackedranking/persistence/TrackedRanking.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.statistics.trackedranking.persistence;
+package de.adesso.kicker.user.trackedranking.persistence;
 
 import de.adesso.kicker.user.persistence.User;
 import lombok.Data;

--- a/src/main/java/de/adesso/kicker/user/trackedranking/persistence/TrackedRankingRepository.java
+++ b/src/main/java/de/adesso/kicker/user/trackedranking/persistence/TrackedRankingRepository.java
@@ -1,4 +1,4 @@
-package de.adesso.kicker.statistics.trackedranking.persistence;
+package de.adesso.kicker.user.trackedranking.persistence;
 
 import de.adesso.kicker.user.persistence.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/de/adesso/kicker/user/trackedranking/service/TrackedRankingService.java
+++ b/src/main/java/de/adesso/kicker/user/trackedranking/service/TrackedRankingService.java
@@ -1,9 +1,9 @@
-package de.adesso.kicker.statistics.trackedranking.service;
+package de.adesso.kicker.user.trackedranking.service;
 
-import de.adesso.kicker.statistics.trackedranking.persistence.TrackedRanking;
-import de.adesso.kicker.statistics.trackedranking.persistence.TrackedRankingRepository;
 import de.adesso.kicker.user.persistence.User;
 import de.adesso.kicker.user.service.UserService;
+import de.adesso.kicker.user.trackedranking.persistence.TrackedRanking;
+import de.adesso.kicker.user.trackedranking.persistence.TrackedRankingRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,119 +1,124 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
-  <title>adesso kicker</title>
+    <title>adesso kicker</title>
 
-  <!-- Required meta tags -->
-  <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <!-- Required meta tags -->
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-  <!-- JQuery -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <!-- JQuery -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 
-  <!-- Bootstrap -->
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
+    <!-- Bootstrap -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
 
-  <!-- Fontawesome -->
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.0/css/all.css">
+    <!-- Fontawesome -->
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.0/css/all.css">
 
-  <!-- Hover CSS -->
-  <link rel="stylesheet" type="text/css" href="/css/hover-min.css">
+    <!-- Hover CSS -->
+    <link rel="stylesheet" type="text/css" href="/css/hover-min.css">
 
-  <!-- My stylesheets -->
-  <link rel="stylesheet/less" type="text/css" href="/css/header.less">
+    <!-- My stylesheets -->
+    <link rel="stylesheet/less" type="text/css" href="/css/header.less">
 
-  <!-- LESS -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/3.9.0/less.min.js"></script>
+    <!-- LESS -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/3.9.0/less.min.js"></script>
 </head>
 <body>
 <!-- Header Template -->
 <header th:fragment="header">
-  <nav class="navbar navbar-light navbar-expand-lg">
-    <!-- Logo -->
-    <a class="navbar-brand" href="#">
-      <img class="adesso-logo" src="/img/adesso-logo.png" alt="adesso kicker">
-    </a>
-    <!-- Links -->
-    <div class="navbar-collapse collapse">
-      <ul class="navbar-nav">
-        <li class="nav-item header-link">
-          <a class="nav-link" th:href="@{/matches/add}">
-            <i class="fa fa-calendar-check hvr-icon"></i>
-            <span class="nav-link hvr-underline-from-left" th:text="#{header.matchRequest}"></span>
-          </a>
-        </li>
-        <li class="nav-item header-link">
-          <a class="nav-link" th:href="@{/ranking}">
-            <i class="fa fa-trophy hvr-icon"></i>
-            <span class="nav-link hvr-underline-from-left" th:text="#{header.ranking}"></span>
-          </a>
-        </li>
-        <li class="nav-item header-link">
-          <a class="nav-link" th:href="@{/users/you}">
-            <i class="fa fa-user hvr-icon"></i>
-            <span class="nav-link hvr-underline-from-left" th:text="#{header.profile}"></span>
-          </a>
-        </li>
-      </ul>
-    </div>
-    <!-- Notification Dropdown -->
-    <div class="dropdown ml-auto" id="notification-dropdown" sec:authorize="isAuthenticated()">
-      <button onblur="toggleEnvelope()" onfocus="toggleEnvelope()"
-              type="button" class="btn header-dropdown-bt hvr-fade" id="notification-dropdown-icon"
-              data-toggle="dropdown">
-        <i class="fa fa-envelope hvr-icon"></i>
-        <span th:if="${!notifications.isEmpty()}" class="badge" id="notification-badge"
-              th:value="${notifications.size()}" th:text="${notifications.size()}"></span>
-      </button>
-      <div class="shadow dropdown-menu-anim-in dropdown-menu dropdown-menu-right" id="notification-dropdown-menu"
-           th:if="${notifications}">
-        <!-- No Notifications Info -->
-        <div id="no-notifications" th:style="${!notifications.isEmpty() ? 'display: none;' : ''}" th:text="#{notification.noNotifications}"></div>
-        <!-- Notifications -->
-        <div class="notification" th:each="notification : ${notifications}">
-          <div
-              th:if="${notification.type == T(de.adesso.kicker.notification.persistence.NotificationType).MATCH_VERIFICATION}">
-            <div th:replace="~{fragments/matchverification.html :: matchverification}"></div>
-          </div>
-          <div th:if="${notification.type == T(de.adesso.kicker.notification.persistence.NotificationType).MESSAGE}">
-            <div th:replace="~{fragments/message.html :: message}"></div>
-          </div>
+    <nav class="navbar navbar-light navbar-expand-lg">
+        <!-- Logo -->
+        <a class="navbar-brand" href="#">
+            <img class="adesso-logo" src="/img/adesso-logo.png" alt="adesso kicker">
+        </a>
+        <!-- Links -->
+        <div class="navbar-collapse collapse">
+            <ul class="navbar-nav">
+                <li class="nav-item header-link">
+                    <a class="nav-link" th:href="@{/matches/add}">
+                        <i class="fa fa-calendar-check hvr-icon"></i>
+                        <span class="nav-link hvr-underline-from-left" th:text="#{header.matchRequest}"></span>
+                    </a>
+                </li>
+                <li class="nav-item header-link">
+                    <a class="nav-link" th:href="@{/ranking}">
+                        <i class="fa fa-trophy hvr-icon"></i>
+                        <span class="nav-link hvr-underline-from-left" th:text="#{header.ranking}"></span>
+                    </a>
+                </li>
+                <li class="nav-item header-link">
+                    <a class="nav-link" th:href="@{/users/you}">
+                        <i class="fa fa-user hvr-icon"></i>
+                        <span class="nav-link hvr-underline-from-left" th:text="#{header.profile}"></span>
+                    </a>
+                </li>
+            </ul>
         </div>
-      </div>
-    </div>
-    <div sec:authorize="!isAuthenticated()">
-      <a type="button" class="btn btn-primary hvr-fade" id="login-button" href="/sso/login" th:text="#{header.login}"></a>
-    </div>
-    <!-- Profile Settings -->
-    <div class="dropdown ml-auto" id="profile-dropdown" sec:authorize="isAuthenticated()">
-      <button type="button" class="btn dropdown-toggle header-dropdown-bt hvr-fade" data-toggle="dropdown">
-        <!-- User Name -->
-        <span th:text="${#authentication.getName()}"></span>
-      </button>
-      <div class="shadow dropdown-menu-anim-in dropdown-menu dropdown-menu-right" id="profile-dropdown-menu">
-        <div class="dropdown-item">
-          <i class="fa fa-calendar-check hvr-icon"></i>
-          <a class="move-2px-right adesso-blue-text" th:href="@{/matches/add}" th:text="#{header.matchRequest}"></a>
+        <!-- Notification Dropdown -->
+        <div class="dropdown ml-auto" id="notification-dropdown" sec:authorize="isAuthenticated()"
+             th:with="notifications=${@notificationService.getNotificationsByReceiver(@userService.getLoggedInUser())}">
+            <button onblur="toggleEnvelope()" onfocus="toggleEnvelope()"
+                    type="button" class="btn header-dropdown-bt hvr-fade" id="notification-dropdown-icon"
+                    data-toggle="dropdown">
+                <i class="fa fa-envelope hvr-icon"></i>
+                <span th:if="${!notifications.isEmpty()}" class="badge" id="notification-badge"
+                      th:value="${notifications.size()}" th:text="${notifications.size()}"></span>
+            </button>
+            <div class="shadow dropdown-menu-anim-in dropdown-menu dropdown-menu-right" id="notification-dropdown-menu"
+                 th:if="${notifications}">
+                <!-- No Notifications Info -->
+                <div id="no-notifications" th:style="${!notifications.isEmpty() ? 'display: none;' : ''}"
+                     th:text="#{notification.noNotifications}"></div>
+                <!-- Notifications -->
+                <div class="notification" th:each="notification : ${notifications}">
+                    <div
+                            th:if="${notification.type == T(de.adesso.kicker.notification.persistence.NotificationType).MATCH_VERIFICATION}">
+                        <div th:replace="~{fragments/matchverification.html :: matchverification}"></div>
+                    </div>
+                    <div th:if="${notification.type == T(de.adesso.kicker.notification.persistence.NotificationType).MESSAGE}">
+                        <div th:replace="~{fragments/message.html :: message}"></div>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="dropdown-item">
-          <i class="fa fa-trophy hvr-icon move-1px-left"></i>
-          <a class="adesso-blue-text" th:href="@{/ranking}" th:text="#{header.ranking}"></a>
+        <div sec:authorize="!isAuthenticated()">
+            <a type="button" class="btn btn-primary hvr-fade" id="login-button" href="/sso/login"
+               th:text="#{header.login}"></a>
         </div>
-        <div class="dropdown-item">
-          <i class="fa fa-user hvr-icon"></i>
-          <a class="move-2px-right adesso-blue-text" th:href="@{/users/you}" th:text="#{header.profile}"></a>
+        <!-- Profile Settings -->
+        <div class="dropdown ml-auto" id="profile-dropdown" sec:authorize="isAuthenticated()">
+            <button type="button" class="btn dropdown-toggle header-dropdown-bt hvr-fade" data-toggle="dropdown">
+                <!-- User Name -->
+                <span th:text="${#authentication.getName()}"></span>
+            </button>
+            <div class="shadow dropdown-menu-anim-in dropdown-menu dropdown-menu-right" id="profile-dropdown-menu">
+                <div class="dropdown-item">
+                    <i class="fa fa-calendar-check hvr-icon"></i>
+                    <a class="move-2px-right adesso-blue-text" th:href="@{/matches/add}"
+                       th:text="#{header.matchRequest}"></a>
+                </div>
+                <div class="dropdown-item">
+                    <i class="fa fa-trophy hvr-icon move-1px-left"></i>
+                    <a class="adesso-blue-text" th:href="@{/ranking}" th:text="#{header.ranking}"></a>
+                </div>
+                <div class="dropdown-item">
+                    <i class="fa fa-user hvr-icon"></i>
+                    <a class="move-2px-right adesso-blue-text" th:href="@{/users/you}" th:text="#{header.profile}"></a>
+                </div>
+                <div class="dropdown-divider"></div>
+                <div class="dropdown-item hvr-icon-back">
+                    <i class="fa fa-sign-out-alt hvr-icon"></i>
+                    <a class="move-2px-right adesso-blue-text" th:href="@{/logout}"
+                       th:text="#{header.logout}">Logout</a>
+                </div>
+            </div>
         </div>
-        <div class="dropdown-divider"></div>
-        <div class="dropdown-item hvr-icon-back">
-          <i class="fa fa-sign-out-alt hvr-icon"></i>
-          <a class="move-2px-right adesso-blue-text" th:href="@{/logout}" th:text="#{header.logout}">Logout</a>
-        </div>
-      </div>
-    </div>
-  </nav>
-  <script src="/js/header.js"></script>
-  <script src="/js/notifications.js"></script>
+    </nav>
+    <script src="/js/header.js"></script>
+    <script src="/js/notifications.js"></script>
 </header>
 </body>
 </html>

--- a/src/test/java/de/adesso/kicker/email/EmailServiceTest.java
+++ b/src/test/java/de/adesso/kicker/email/EmailServiceTest.java
@@ -1,8 +1,8 @@
 package de.adesso.kicker.email;
 
-import de.adesso.kicker.events.match.MatchVerificationSentEvent;
 import de.adesso.kicker.match.persistence.Match;
 import de.adesso.kicker.notification.matchverificationrequest.persistence.MatchVerificationRequest;
+import de.adesso.kicker.notification.matchverificationrequest.service.events.MatchVerificationSentEvent;
 import de.adesso.kicker.user.persistence.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/de/adesso/kicker/events/MatchCreatedEventDummy.java
+++ b/src/test/java/de/adesso/kicker/events/MatchCreatedEventDummy.java
@@ -1,7 +1,7 @@
 package de.adesso.kicker.events;
 
-import de.adesso.kicker.events.match.MatchCreatedEvent;
 import de.adesso.kicker.match.persistence.Match;
+import de.adesso.kicker.match.service.events.MatchCreatedEvent;
 
 public class MatchCreatedEventDummy {
 

--- a/src/test/java/de/adesso/kicker/events/MatchDeclinedEventDummy.java
+++ b/src/test/java/de/adesso/kicker/events/MatchDeclinedEventDummy.java
@@ -1,7 +1,7 @@
 package de.adesso.kicker.events;
 
-import de.adesso.kicker.events.match.MatchDeclinedEvent;
 import de.adesso.kicker.match.MatchDummy;
+import de.adesso.kicker.match.service.events.MatchDeclinedEvent;
 
 public class MatchDeclinedEventDummy {
 

--- a/src/test/java/de/adesso/kicker/events/MatchVerifiedEventDummy.java
+++ b/src/test/java/de/adesso/kicker/events/MatchVerifiedEventDummy.java
@@ -1,7 +1,7 @@
 package de.adesso.kicker.events;
 
-import de.adesso.kicker.events.match.MatchVerifiedEvent;
 import de.adesso.kicker.match.MatchDummy;
+import de.adesso.kicker.match.service.events.MatchVerifiedEvent;
 
 public class MatchVerifiedEventDummy {
 

--- a/src/test/java/de/adesso/kicker/match/MatchControllerIntegrationTest.java
+++ b/src/test/java/de/adesso/kicker/match/MatchControllerIntegrationTest.java
@@ -1,9 +1,9 @@
 package de.adesso.kicker.match;
 
 import de.adesso.kicker.email.EmailService;
-import de.adesso.kicker.events.match.MatchVerificationSentEvent;
 import de.adesso.kicker.match.persistence.MatchRepository;
 import de.adesso.kicker.notification.matchverificationrequest.persistence.MatchVerificationRequestRepository;
+import de.adesso.kicker.notification.matchverificationrequest.service.events.MatchVerificationSentEvent;
 import de.adesso.kicker.user.persistence.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/de/adesso/kicker/match/MatchControllerTest.java
+++ b/src/test/java/de/adesso/kicker/match/MatchControllerTest.java
@@ -42,10 +42,10 @@ class MatchControllerTest {
     @MockBean
     MatchService matchService;
 
-    @MockBean
+    @MockBean(name = "userService")
     UserService userService;
 
-    @MockBean
+    @MockBean(name = "notificationService")
     NotificationService notificationService;
 
     @Autowired
@@ -79,8 +79,7 @@ class MatchControllerTest {
                 .andExpect(view().name("sites/matchresult.html"))
                 .andExpect(model().attribute("match", new Match()))
                 .andExpect(model().attribute("currentUser", user))
-                .andExpect(model().attribute("users", userList))
-                .andExpect(model().attribute("notifications", notificationList));
+                .andExpect(model().attribute("users", userList));
     }
 
     @Test

--- a/src/test/java/de/adesso/kicker/match/MatchServiceTest.java
+++ b/src/test/java/de/adesso/kicker/match/MatchServiceTest.java
@@ -2,14 +2,14 @@ package de.adesso.kicker.match;
 
 import de.adesso.kicker.events.MatchDeclinedEventDummy;
 import de.adesso.kicker.events.MatchVerifiedEventDummy;
-import de.adesso.kicker.events.match.MatchCreatedEvent;
 import de.adesso.kicker.match.exception.FutureDateException;
 import de.adesso.kicker.match.exception.InvalidCreatorException;
 import de.adesso.kicker.match.exception.SamePlayerException;
 import de.adesso.kicker.match.persistence.Match;
 import de.adesso.kicker.match.persistence.MatchRepository;
 import de.adesso.kicker.match.service.MatchService;
-import de.adesso.kicker.statistics.ranking.service.RankingService;
+import de.adesso.kicker.match.service.events.MatchCreatedEvent;
+import de.adesso.kicker.user.service.RankingService;
 import de.adesso.kicker.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -114,7 +114,6 @@ class MatchServiceTest {
         // then
         assertTrue(match.isVerified());
         then(matchRepository).should(times(1)).save(match);
-        then(rankingService).should(times(1)).updateRatings(match);
     }
 
     @ParameterizedTest

--- a/src/test/java/de/adesso/kicker/notification/matchverificationrequest/VerifyMatchServiceTest.java
+++ b/src/test/java/de/adesso/kicker/notification/matchverificationrequest/VerifyMatchServiceTest.java
@@ -1,10 +1,10 @@
 package de.adesso.kicker.notification.matchverificationrequest;
 
 import de.adesso.kicker.events.MatchCreatedEventDummy;
-import de.adesso.kicker.events.match.MatchDeclinedEvent;
-import de.adesso.kicker.events.match.MatchVerifiedEvent;
 import de.adesso.kicker.match.MatchDummy;
 import de.adesso.kicker.match.persistence.Match;
+import de.adesso.kicker.match.service.events.MatchDeclinedEvent;
+import de.adesso.kicker.match.service.events.MatchVerifiedEvent;
 import de.adesso.kicker.notification.matchverificationrequest.persistence.MatchVerificationRequest;
 import de.adesso.kicker.notification.matchverificationrequest.persistence.MatchVerificationRequestRepository;
 import de.adesso.kicker.notification.matchverificationrequest.service.VerifyMatchService;

--- a/src/test/java/de/adesso/kicker/site/controller/HomeControllerTest.java
+++ b/src/test/java/de/adesso/kicker/site/controller/HomeControllerTest.java
@@ -38,7 +38,7 @@ class HomeControllerTest {
     @MockBean(name = "userService")
     private UserService userService;
 
-    @MockBean
+    @MockBean(name = "notificationService")
     private NotificationService notificationService;
 
     private static User createUserWithRank() {
@@ -73,7 +73,6 @@ class HomeControllerTest {
         result.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(model().attribute("user", false))
-                .andExpect(model().attribute("notifications", false))
                 .andExpect(model().attribute("users", userList))
                 .andExpect(model().attribute("allUsers", userList))
                 .andExpect(content().string(containsString("id=\"login-button\"")));
@@ -97,7 +96,6 @@ class HomeControllerTest {
         result.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(model().attribute("user", user))
-                .andExpect(model().attribute("notifications", notifications))
                 .andExpect(model().attribute("allUsers", userList))
                 .andExpect(content().string(containsString("id=\"user-self\"")))
                 .andExpect(content().string(containsString("id=\"notification-dropdown\"")))

--- a/src/test/java/de/adesso/kicker/statistics/ranking/RankingDummy.java
+++ b/src/test/java/de/adesso/kicker/statistics/ranking/RankingDummy.java
@@ -1,6 +1,6 @@
 package de.adesso.kicker.statistics.ranking;
 
-import de.adesso.kicker.statistics.ranking.persistence.Ranking;
+import de.adesso.kicker.user.persistence.Ranking;
 
 public class RankingDummy {
     public static Ranking ranking() {

--- a/src/test/java/de/adesso/kicker/statistics/ranking/service/RankingServiceTest.java
+++ b/src/test/java/de/adesso/kicker/statistics/ranking/service/RankingServiceTest.java
@@ -1,11 +1,11 @@
-package de.adesso.kicker.statistics.ranking;
+package de.adesso.kicker.statistics.ranking.service;
 
 import de.adesso.kicker.match.MatchDummy;
-import de.adesso.kicker.statistics.ranking.persistence.Ranking;
-import de.adesso.kicker.statistics.ranking.persistence.RankingRepository;
-import de.adesso.kicker.statistics.ranking.service.RankingService;
+import de.adesso.kicker.statistics.ranking.RankingDummy;
+import de.adesso.kicker.user.persistence.Ranking;
+import de.adesso.kicker.user.persistence.RankingRepository;
 import de.adesso.kicker.user.persistence.User;
-import org.junit.jupiter.api.Assertions;
+import de.adesso.kicker.user.service.RankingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,7 +45,7 @@ class RankingServiceTest {
         var match = MatchDummy.matchWithLowRating();
 
         // when
-        rankingService.updateRatings(match);
+        rankingService.updateRatings(match.getWinners(), match.getLosers());
 
         // then
         assertRatingPlayers(1016, match.getWinners());
@@ -59,7 +59,7 @@ class RankingServiceTest {
         var match = MatchDummy.matchWithHighRating();
 
         // when
-        rankingService.updateRatings(match);
+        rankingService.updateRatings(match.getWinners(), match.getLosers());
 
         // then
         assertRatingPlayers(2112, match.getWinners());
@@ -73,7 +73,7 @@ class RankingServiceTest {
         var match = MatchDummy.matchWithVeryHighRating();
 
         // when
-        rankingService.updateRatings(match);
+        rankingService.updateRatings(match.getWinners(), match.getLosers());
 
         // then
         assertRatingPlayers(2408, match.getWinners());
@@ -88,7 +88,7 @@ class RankingServiceTest {
         given(rankingRepository.save(any(Ranking.class))).willReturn(new Ranking());
 
         // when
-        rankingService.updateRatings(match);
+        rankingService.updateRatings(match.getWinners(), match.getLosers());
 
         // then
         assertRatingPlayers(1032, match.getWinners());
@@ -126,7 +126,7 @@ class RankingServiceTest {
     private static void assertRatingPlayers(int expected, List<User> players) {
         for (var player : players) {
             var actual = player.getRanking().getRating();
-            Assertions.assertEquals(expected, actual);
+            assertEquals(expected, actual);
         }
     }
 }

--- a/src/test/java/de/adesso/kicker/user/UserControllerTest.java
+++ b/src/test/java/de/adesso/kicker/user/UserControllerTest.java
@@ -38,10 +38,10 @@ class UserControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockBean(name = "userService")
     private UserService userService;
 
-    @MockBean
+    @MockBean(name = "notificationService")
     private NotificationService notificationService;
 
     @Test
@@ -57,9 +57,7 @@ class UserControllerTest {
         var result = mockMvc.perform(get("/users/you"));
 
         // then
-        result.andExpect(status().isOk())
-                .andExpect(model().attribute("user", user))
-                .andExpect(model().attribute("notifications", notificationList));
+        result.andExpect(status().isOk()).andExpect(model().attribute("user", user));
     }
 
     @Test

--- a/src/test/java/de/adesso/kicker/user/UserServiceTest.java
+++ b/src/test/java/de/adesso/kicker/user/UserServiceTest.java
@@ -1,9 +1,9 @@
 package de.adesso.kicker.user;
 
-import de.adesso.kicker.statistics.ranking.service.RankingService;
 import de.adesso.kicker.user.exception.UserNotFoundException;
 import de.adesso.kicker.user.persistence.User;
 import de.adesso.kicker.user.persistence.UserRepository;
+import de.adesso.kicker.user.service.RankingService;
 import de.adesso.kicker.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -162,7 +162,7 @@ class UserServiceTest {
         given(userRepository.findById(anyString())).willReturn(Optional.empty());
         given(userRepository.save(user)).willReturn(user);
 
-        doNothing().when(rankingService).updateRanks();
+//        doNothing().when(rankingService).updateRanks();
 
         // when
         userService.checkFirstLogin(authEvent);


### PR DESCRIPTION
Mostly it is just packages being moved around. The exception to this
was the "ranking" package. Due to it's close relation to the "user"
package the only easy fix to this was removing the "ranking" package and
making it part of the "user" package. This has solved the dependency
and should break nothing in the frontend as the fields remained the
same.

I also moved the "trackedrankings" package into the "user" package as it made little sense to me to have it in it's own package.

Please note that I myself am not too sure about these changes and if anybody has a better idea/solution can gladly share it with me.

Also I couldn't fully test the frontend due to a lack of test integration tests for notifications.

EDIT:
Wait with merging until #244 has been merged or closed.