### PR TITLE
Make matchresult more usable for mobile devices

### DIFF
--- a/src/main/resources/static/css/matchresult.less
+++ b/src/main/resources/static/css/matchresult.less
@@ -141,3 +141,5 @@
     opacity: 1;
   }
 }
+
+body { min-width: 320px; }

--- a/src/main/resources/static/css/matchresult.less
+++ b/src/main/resources/static/css/matchresult.less
@@ -32,7 +32,7 @@
 }
 
 #info-tooltip {
-  text-align: center;
+  text-align: right;
   .fa-info-circle {
     @media @mobile, @tablet {margin-left: -30px;}
     color: @colorscheme[adesso-blue];
@@ -42,7 +42,7 @@
 }
 
 .team {
-  height: 40px;
+  height: 30%;
   color: @colorscheme[warm-grey-darker];
   &-description {
     font-size: 15px;
@@ -97,7 +97,11 @@
   color: white;
 }
 
-#datetimepicker-form-group {width: 41%;}
+#datetimepicker-form-group {
+  padding-left: 0;
+  width: 43%;
+  @media @mobile { width: 90% }
+}
 
 .popup {
   opacity: 0;

--- a/src/main/resources/static/css/profile.less
+++ b/src/main/resources/static/css/profile.less
@@ -71,3 +71,5 @@
     opacity: 1;
   }
 }
+
+body { min-width: 320px; }

--- a/src/main/resources/templates/sites/matchresult.html
+++ b/src/main/resources/templates/sites/matchresult.html
@@ -67,7 +67,7 @@
     <div class="row">
       <!-- Team A -->
       <div class="col-sm-6">
-        <p class="team-description" th:text="#{matchResult.teamA}"></p>
+        <div class="team-description" th:text="#{matchResult.teamA}"></div>
         <div class="team team-textbox">
           <!-- As we want to display the user in a disabled input text field, we cant add the field value to it.
                As Thymeleaf wouldn't use it for the form, so were creating a hidden input field.
@@ -92,9 +92,10 @@
           </div>
         </div>
       </div>
+      <!--<div class="w-100"></div>-->
       <!-- Team B -->
       <div class="col-sm-6">
-        <p class="team-description" th:text="#{matchResult.teamB}"></p>
+        <div class="team-description" th:text="#{matchResult.teamB}"></div>
         <!-- Searchbar -->
         <div class="team team-textbox search-bar">
           <div class="input-group">
@@ -171,14 +172,15 @@
       <i class="fa fa-times" aria-hidden="true"></i>
       <span th:text="#{matchResult.error.noDate}"></span>
     </div>
-    <div class="form-group" id="datetimepicker-form-group">
-      <div class="input-group date">
-        <input type="date" th:field="*{date}" id="datetimepicker" class="form-control" th:max="${#dates.format(#dates.createNow(), 'yyyy-MM-dd')}">
-        <div class="input-group-append">
-          <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+      <div class="form-group col-sm-6" id="datetimepicker-form-group">
+        <div class="input-group date">
+          <input type="date" th:field="*{date}" id="datetimepicker" class="form-control"
+                 th:max="${#dates.format(#dates.createNow(), 'yyyy-MM-dd')}">
+          <div class="input-group-append">
+            <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+          </div>
         </div>
       </div>
-    </div>
     <!-- Submit Match -->
     <div>
       <div class="popup popup-success" th:if="${successMessage}">


### PR DESCRIPTION
This is done as part of #193 
The datepicker now scales properly with size of device.
"Team B" doesn't overlap with the team A player B input field anymore.
The tooltip is now on the right instead of the middle.